### PR TITLE
Remediation: Upgrade serialize-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "^4.2.0",
+    "serialize-javascript": "2.1.1",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6280,6 +6280,11 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
+serialize-javascript@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.1.tgz#952907a04a3e3a75af7f73d92d15e233862048b2"
+  integrity sha512-MPLPRpD4FNqWq9tTIjYG5LesFouDhdyH0EPY3gVK4DRD5+g4aDqdNSzLIwceulo3Yj+PL1bPh6laE5+H6LTcrQ==
+
 serialize-javascript@^1.4.0, serialize-javascript@^1.7.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"


### PR DESCRIPTION
#### [GHSA-h9rv-jmmf-4pgx](https://github.com/advisories/GHSA-h9rv-jmmf-4pgx)
##### Vulnerable versions: < 2.1.1
##### Patched version: 2.1.1

## regular expressions Cross-Site Scripting (XSS) vulnerability
### Impact
Affected versions of this package are vulnerable to Cross-site Scripting (XSS). It does not properly mitigate against unsafe characters in serialized regular expressions.

This vulnerability is not affected on Node.js environment since Node.js's implementation of `RegExp.prototype.toString()` backslash-escapes all forward slashes in regular expressions.

If serialized data of regular expression objects are used in an environment other than Node.js, it is affected by this vulnerability.